### PR TITLE
Update Linker script template splitting method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,13 @@ INITIAL_COMPILATION: UNCHECKED_OBJS
 	@test -d $(BIN_DIR) || mkdir -p $(BIN_DIR)
 	@$(CC) -o $(BIN_DIR)/initial$(TARGET).elf $(INITIAL_LINKERSCRIPT) $(LDFLAGS) $(OBJ) $(TRACE_OBJ) $(ASRC:%.s=$(BUILD_DIR)/%.o) $(LDLIBS)
 
+
 INITIAL_PROFILER: INITIAL_COMPILATION
 	@echo "Starting Initial Profiler"
-	@test -d seu/gen || mkdir -p seu/gen
+	@test -d $(SEU_GEN_DIR) || mkdir -p $(SEU_GEN_DIR)
 	@$(READELF) --wide -s binary/initialFreeRTOS.elf| grep " FUNC    " | awk '{print $$3 " " $$8 }' | sort -k 2 | uniq -u  > seu/gen/fullMap.data
-	@$(PYTHON) seu/initial_profiler.py
+	@awk '/\*{6}/{x++}{print >"seu/gen/template_half_" x ".ld" }' x=0 seu/initial_seu_link.ld #Split Linker script in half 
+	@$(PYTHON) $(SEU_DIR)/initial_profiler.py
 	@echo "initial Profiler Completed"
 
 SECONDARY_COMPILATION: INITIAL_PROFILER

--- a/seu/initial_seu_link.ld
+++ b/seu/initial_seu_link.ld
@@ -36,7 +36,7 @@ MEMORY
 
 SECTIONS
 {
-
+    /******/
     .text :
     {
         . = ALIGN(4);
@@ -59,7 +59,7 @@ SECTIONS
  	  	   _fini = . ;
 		   *(.fini)
 
-    } > flash17
+    } > flash10
 
     .data :
     {


### PR DESCRIPTION
Removed the hard-coded template data lengths read from the linker script template file.

Misc change in Makefile cleanup I missed earlier.