### PR TITLE
Add secondary profiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,13 @@ INITIAL_COMPILATION: UNCHECKED_OBJS
 	@test -d $(BIN_DIR) || mkdir -p $(BIN_DIR)
 	@$(CC) -o $(BIN_DIR)/initial$(TARGET).elf $(INITIAL_LINKERSCRIPT) $(LDFLAGS) $(OBJ) $(TRACE_OBJ) $(ASRC:%.s=$(BUILD_DIR)/%.o) $(LDLIBS)
 
+
 INITIAL_PROFILER: INITIAL_COMPILATION
 	@echo "Starting Initial Profiler"
-	@test -d seu/gen || mkdir -p seu/gen
+	@test -d $(SEU_GEN_DIR) || mkdir -p $(SEU_GEN_DIR)
 	@$(READELF) --wide -s binary/initialFreeRTOS.elf| grep " FUNC    " | awk '{print $$3 " " $$8 }' | sort -k 2 | uniq -u  > seu/gen/fullMap.data
-	@$(PYTHON) seu/initial_profiler.py
+	@awk '/\*{6}/{x++}{print >"seu/gen/template_half_" x ".ld" }' x=0 seu/initial_seu_link.ld #Split Linker script in half 
+	@$(PYTHON) $(SEU_DIR)/initial_profiler.py
 	@echo "initial Profiler Completed"
 
 SECONDARY_COMPILATION: INITIAL_PROFILER

--- a/seu/initial_seu_link.ld
+++ b/seu/initial_seu_link.ld
@@ -36,7 +36,7 @@ MEMORY
 
 SECTIONS
 {
-
+    /******/
     .text :
     {
         . = ALIGN(4);
@@ -59,7 +59,7 @@ SECTIONS
  	  	   _fini = . ;
 		   *(.fini)
 
-    } > flash17
+    } > flash10
 
     .data :
     {

--- a/seu/secondary_profiler.py
+++ b/seu/secondary_profiler.py
@@ -1,0 +1,57 @@
+#
+# SEU detection and correction
+# Copyright (C) 2015 Nano Avionics
+#
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import subprocess
+
+NUMBER_TEXT_SECTIONS = 4
+NUM_IGNORE_BYTES = 16 #number of bytes to ignore from start of section 
+
+current_path = os.path.dirname(os.path.abspath(__file__))
+hex_dump_filename = os.path.join(current_path, 'gen', 'text_hex_dump_%s.hex')
+crc_exe_path = os.path.join(current_path, '..', 'build', 'crcGenerator')
+
+section_name = 'text%s'
+
+class TextSectionObj:
+    def __init__(self, name, number):
+        self.name = name
+        self.contents = ''
+        self.crc = 0
+
+section_arr = []
+for idx in range(1, NUMBER_TEXT_SECTIONS):
+    name = section_name % idx
+    section_arr.append(TextSectionObj(name, idx))
+
+
+for x in range(1, NUMBER_TEXT_SECTIONS):
+    file_name = hex_dump_filename % x
+    content_str = ''
+    with open(file_name, 'r') as hex_file:
+        for line in hex_file:
+            content_str += line.strip()
+    start_idx = 2 * NUM_IGNORE_BYTES # contents are hex encoded, 2 hex chars per byte
+    reduced_contents = content_str[start_idx:] #drop the block header from the hex dump
+    output = subprocess.check_output([crc_exe_path, reduced_contents])
+    crc = output
+    print ('crc: ', crc)
+
+
+


### PR DESCRIPTION
### Added secondary_profiler.py 

 - Does not handle RS-parity data at the moment (Not added if it is going to get separated out) 
 - Added loop in Makefile to generate hex dumps of .text subsections. 
 - Loop structure in secondary_profiler.py works but not finalized  
	 - The specifics of these will need to change based on flash/.text subsection definitions but basic structure should be working.