### PR TITLE
Update crc generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ INCLUDE+=-I$(REED_SOLOMON)/include
 
 BUILD_DIR = $(CURDIR)/build
 BIN_DIR = $(CURDIR)/binary
-SEU_DIR = seu/
+SEU_DIR = seu
 SEU_SRC_DIR = $(SEU_DIR)/src
 SEU_GEN_DIR = $(SEU_DIR)/gen
 
@@ -102,15 +102,17 @@ GCC=gcc #Standard Desktop GCC
 PYTHON = python3
 
 OBJ = $(SRC:%.c=$(BUILD_DIR)/%.o)
+REED_SOLOMON_SRC := $(REED_SOLOMON)/src/alpha_to.c $(REED_SOLOMON)/src/index_of.c $(REED_SOLOMON)/src/genpoly.c
+REED_SOLOMON_OBJ := $(BUILD_DIR)/alpha_to.o $(BUILD_DIR)/index_of.o $(BUILD_DIR)/genpoly.o
 
 all: utils SECONDARY_PROFILER
 
 utils:
 	@echo [CC] crcGenerator.c
 	@test -d $(BUILD_DIR) || mkdir -p $(BUILD_DIR)
-	@$(GCC) $(CRC_SRCS) -I$(REED_SOLOMON)/include -o $(BUILD_DIR)/crcGenerator
+	$(GCC) $(CRC_SRCS) $(REED_SOLOMON_SRC) $(INCLUDE) -I$(REED_SOLOMON)/include $(DBG) -o $(BUILD_DIR)/crcGenerator
 
-REED_SOLOMON_OBJS: $(BUILD_DIR)/alpha_to.o $(BUILD_DIR)/index_of.o $(BUILD_DIR)/genpoly.o
+REED_SOLOMON_OBJS: $(REED_SOLOMON_OBJ)
 
 $(BUILD_DIR)/alpha_to.o: $(REED_SOLOMON)/src/alpha_to.c $(REED_SOLOMON)/include/*
 	@echo [CC] $(notdir $<)
@@ -138,7 +140,7 @@ INITIAL_COMPILATION: UNCHECKED_OBJS REED_SOLOMON_OBJS
 	@$(AS) -o $(ASRC:%.s=$(BUILD_DIR)/%.o) $(STARTUP)/$(ASRC)
 	@echo [LD] $(TARGET).elf
 	@test -d $(BIN_DIR) || mkdir -p $(BIN_DIR)
-	@$(CC) -o $(BIN_DIR)/initial$(TARGET).elf $(INITIAL_LINKERSCRIPT) $(LDFLAGS) $(OBJ) $REED_SOLOMON_OBJS) $(TRACE_OBJ) $(ASRC:%.s=$(BUILD_DIR)/%.o) $(LDLIBS)
+	@$(CC) -o $(BIN_DIR)/initial$(TARGET).elf $(INITIAL_LINKERSCRIPT) $(LDFLAGS) $(OBJ) $(REED_SOLOMON_OBJ) $(TRACE_OBJ) $(ASRC:%.s=$(BUILD_DIR)/%.o) $(LDLIBS)
 
 
 INITIAL_PROFILER: INITIAL_COMPILATION

--- a/seu/include/crc_generator.h
+++ b/seu/include/crc_generator.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Nano Avionics
+ *
+ * Licensed under the GNU GENERAL PUBLIC LICENSE, Version 3 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License from the Free Software Foundation, Inc.
+ * at
+ *
+ *    http://fsf.org/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include <stdint.h>
+#include "reed_solomon.h"
+
+typedef struct block { 
+    uint16_t    reed_solomon_data[SYMBOL_TABLE_WORDS];
+    uint32_t    crc;
+} block_t;
+
+struct blockWrapper { 
+    uint32_t    block_count;
+    block_t*    data;
+};

--- a/seu/secondary_profiler.py
+++ b/seu/secondary_profiler.py
@@ -49,9 +49,9 @@ for x in range(1, NUMBER_TEXT_SECTIONS):
             content_str += line.strip()
     start_idx = 2 * NUM_IGNORE_BYTES # contents are hex encoded, 2 hex chars per byte
     reduced_contents = content_str[start_idx:] #drop the block header from the hex dump
-    output = subprocess.check_output([crc_exe_path, reduced_contents])
-    crc = output
-    print ('crc: ', crc)
+    # output = subprocess.check_output([crc_exe_path])
+    # crc = output.decode('utf-8')
+    # print ('crc: ', crc)
 
 
 


### PR DESCRIPTION
### Notes on these changes: 

- CRC_Generator should (if there's no arguments included) generate a random test set, encode and then calculate the CRC for the encoded block. It prints the crc followed by what should be the parity symbols for the block.
- The structs for the CRC_Generator are in a new file: seu/include/crc_generator.h.
- CRC_Generator is not called from secondary_profiler at the moment.